### PR TITLE
feat: add ability to parse snippet headers

### DIFF
--- a/lua/cmp_nvim_ultisnips/parser.lua
+++ b/lua/cmp_nvim_ultisnips/parser.lua
@@ -1,0 +1,139 @@
+local M = {}
+
+local function table_is_empty(table)
+  return next(table) == nil
+end
+
+local function iterator_to_table(iterator)
+  local result = {}
+  for x in iterator do
+    table.insert(result, x)
+  end
+  return result
+end
+
+function M.handle_terminal_symbol(symbol, input)
+  local start_idx, end_idx, capture = input:find(symbol)
+  if start_idx ~= nil then
+    local match = capture or input:sub(start_idx, end_idx)
+    local remaining = input:sub(end_idx + 1)
+    return { matches = { match }, remaining = remaining }
+  end
+  return nil
+end
+
+function M.handle_non_terminal_symbol(production_name, grammar, input, force_parse_to_end)
+  local production = grammar.productions[production_name]
+  for _, rule in ipairs(production.rhs) do
+    local matches = {}
+    local cur_input = input
+
+    -- TODO: replace with vim.split
+    local symbols = iterator_to_table(rule:gmatch('%S+'))
+    -- TODO: replace with vim.tbl_isempty
+    if table_is_empty(symbols) then
+      symbols = { rule }
+    end
+
+    for symbol_num, symbol in ipairs(symbols) do
+      local is_terminal_symbol = (grammar.productions[symbol] == nil)
+
+      local result
+      if is_terminal_symbol then
+        result = M.handle_terminal_symbol(symbol, cur_input)
+      else
+        result = M.handle_non_terminal_symbol(symbol, grammar, cur_input)
+      end
+
+      if result ~= nil then
+        -- flatten table returned by handler
+        if #result.matches == 1 then
+          result.matches = result.matches[1]
+        end
+        matches[symbol_num] = result.matches
+        cur_input = result.remaining
+      end
+      -- the rule was successfully applied to the input string
+      if #matches == #symbols then
+        if production_name ~= grammar.start_symbol or (not force_parse_to_end or cur_input == '') then
+        -- Warning: verify function may change the contents of result.matches!
+        -- Always assume that the table contents have changed beyond this point (e.g. when
+        -- logging the current value).
+          if production.verify_matches == nil or production.verify_matches(rule, matches) == true then
+            if production.on_store_matches ~= nil then
+              production.on_store_matches(symbols, matches)
+            end
+            return { matches = matches, remaining = cur_input }
+          end
+        end
+      end
+    end
+  end
+  return nil
+end
+
+function M.parse(input, grammar, force_parse_to_end)
+  return M.handle_non_terminal_symbol(grammar.start_symbol, grammar, input, force_parse_to_end)
+end
+
+local function remove_surrounding_chars(string, tbl, tbl_index)
+  local valid = string:sub(1, 1) == string:sub(-1, -1)
+  if valid then
+    -- this modifies the original captures table!
+    tbl[tbl_index] = string:sub(2, -2)
+  end
+  return valid
+end
+
+function M.parse_snippet_header(input)
+  local result = {}
+  local productions = {
+    S = {
+      rhs = {
+                                             'tab_trigger',
+                               'description w tab_trigger',
+                     'options w description w tab_trigger',
+        'options w expression w description w tab_trigger',
+      },
+      verify_matches = function(rule, matches)
+        local tab_trigger = matches[#matches]
+        if rule == 'options w expression w description w tab_trigger' and tab_trigger:match('e') == nil then
+          return false
+        end
+        local has_r_options = rule:match('options') ~= nil and matches[1]:match('r') ~= nil
+        if has_r_options or tab_trigger:match('%s') then
+          return remove_surrounding_chars(tab_trigger, matches, #matches)
+        end
+        return true
+      end,
+      on_store_matches = function(symbols, matches)
+        for i, match in ipairs(matches) do
+          if symbols[i] ~= 'w' then
+            result[symbols[i]] = match:reverse()
+          end
+        end
+      end
+    },
+    tab_trigger = {
+      rhs = { '^[^"%A]+', '^".-"', '^%S.+%S' },
+    },
+    description = {
+      rhs = { '^"([^"]*)"' }
+    },
+    options = {
+      rhs = { '^[^"%s]+' }
+    },
+    expression = {
+      rhs = { '^"(.-)"' }
+    },
+    w = {
+      rhs = { '^%s+' }
+    }
+  }
+  local grammar = { start_symbol = 'S', productions = productions }
+  -- reverse the string since we need to parse from right to left
+  M.parse(input:reverse(), grammar, true)
+  return result
+end
+
+return M

--- a/lua/cmp_nvim_ultisnips/tests/parser_spec.lua
+++ b/lua/cmp_nvim_ultisnips/tests/parser_spec.lua
@@ -1,0 +1,263 @@
+local parser = require('cmp_nvim_ultisnips.parser')
+
+describe('parser for grammar', function()
+  describe('with terminal symbol', function()
+    it('should match second rule if first one failed', function()
+      local productions = {
+        S = {
+          rhs = { '^%a+', '^%d+'}
+        }
+      }
+      local grammar = { start_symbol = 'S', productions = productions }
+      local result = parser.parse('123 test', grammar, false)
+      assert.is_not_nil(result)
+      local expected = { matches = { '123' }, remaining = ' test' }
+      assert.are_same(expected, result)
+    end)
+
+    it('should match description regex', function()
+      local productions = {
+        S = {
+          rhs = { '^"[^"]+"' }
+        }
+      }
+      local grammar = { start_symbol = 'S', productions = productions }
+      local result = parser.parse('"some description"', grammar, false)
+      assert.is_not_nil(result)
+      local expected = { matches = { '"some description"' }, remaining = '' }
+      assert.are_same(expected, result)
+    end)
+
+    it('should not match', function()
+      local productions = {
+        S = {
+          rhs = { '^%d+'}
+        }
+      }
+      local grammar = { start_symbol = 'S', productions = productions }
+      assert.is_nil(parser.parse('test 123', grammar))
+    end)
+
+    it('should match based on result of verify function', function()
+      local productions = {
+        S = {
+          rhs = { '^%S+' },
+          verify_matches = function(_, matches)
+            -- only match when first char is 'x'
+            return matches[1]:sub(1, 1) == 'x'
+          end
+        }
+      }
+      local grammar = { start_symbol = 'S', productions = productions }
+      local actual = parser.parse('xyz', grammar)
+      assert.is_not_nil(actual)
+      local expected = { matches = { 'xyz' }, remaining = '' }
+      assert.are_same(expected, actual)
+
+      -- failure case
+      assert.is_nil(parser.parse('zyx', grammar))
+    end)
+
+    it('should provide captured values in verify function and result table', function()
+      local captured_rules = {}
+      local captured_matches = {}
+
+      local productions = {
+        S = {
+          rhs = { '^X(.*)X', '^M(.*)M A' },
+          verify_matches = function(rule, matches)
+            table.insert(captured_rules, rule)
+            table.insert(captured_matches, matches)
+            return true
+          end
+        },
+        A = {
+          rhs = { 'a' }
+        }
+      }
+      local grammar = { start_symbol = 'S', productions = productions }
+      local actual = parser.parse('Msome str1ngsM arest', grammar, false)
+
+      -- one call to verify for the applied rule
+      assert.are_same({ '^M(.*)M A' }, captured_rules)
+      assert.are_same({ { 'some str1ngs', 'a' } }, captured_matches)
+
+      assert.is_not_nil(actual)
+      local expected = { matches = { 'some str1ngs', 'a' }, remaining = 'rest' }
+      assert.are_same(expected, actual)
+    end)
+
+    it('should match based on result of verify function (more complex test)', function()
+      local productions = {
+        S = {
+          rhs = { '^.*' },
+          verify_matches = function(_, matches)
+            -- only match when surrounding chars are '!'
+            local valid = matches[1]:sub(1, 1) == '!' and matches[1]:sub(-1, -1) == '!'
+            -- it is possible to change the captured value since captures are passed by reference
+            if valid == true then
+              matches[1] = matches[1]:sub(2, -2)
+            end
+            return valid
+          end
+        }
+      }
+      local grammar = { start_symbol = 'S', productions = productions }
+      local actual = parser.parse('!test!', grammar)
+      assert.is_not_nil(actual)
+      local expected = { matches = { 'test' }, remaining = '' }
+      assert.are_same(expected, actual)
+    end)
+
+    it('should provide matches in on_store_matches when verify succeeded', function()
+      local captured_symbols = {}
+      local captured_matches = {}
+      local productions = {
+        S = {
+          rhs = { 'A C', 'B C' },
+          verify_matches = function(rule, _)
+            -- only allow second rule
+            return rule == 'B C'
+          end,
+          on_store_matches = function(symbols, matches)
+            table.insert(captured_symbols, symbols)
+            table.insert(captured_matches, matches)
+          end
+        },
+        A = {
+          rhs = { 'a' }
+        },
+        B = {
+          rhs = { 'a' }
+        },
+        C = {
+          rhs = { 'c' }
+        }
+      }
+      local grammar = { start_symbol = 'S', productions = productions }
+      local actual = parser.parse('ac', grammar)
+
+      assert.are_same({ { 'B', 'C' } }, captured_symbols)
+      assert.are_same({ { 'a', 'c' } }, captured_matches)
+
+      assert.is_not_nil(actual)
+      local expected = { matches = { 'a', 'c' }, remaining = '' }
+      assert.are_same(expected, actual)
+    end)
+  end)
+
+  describe('with non-terminal symbol', function()
+    it('should match', function()
+      local productions = {
+        S = { rhs = { 'A D' } },
+        A = { rhs = { 'B C' } },
+        B = { rhs = { '^b' } },
+        C = { rhs = { '^c' } },
+        D = { rhs = { '^d' } }
+      }
+      local grammar = { start_symbol = 'S', productions = productions }
+      local expected = {
+        matches = {
+          { 'b', 'c' }, -- matched by non-terminal A
+          'd' -- matched by non-terminal D
+        },
+        remaining = 'rest'
+      }
+      local actual = parser.parse('bcdrest', grammar)
+      assert.is_not_nil(actual)
+      assert.are_same(expected, actual)
+    end)
+
+    it('should not match when last non-terminal fails', function()
+      local productions = {
+        S = { rhs = { 'A D' } },
+        A = { rhs = { 'B C' } },
+        B = { rhs = { '^b' } },
+        C = { rhs = { '^c' } },
+        D = { rhs = { '^d' } }
+      }
+      local grammar = { start_symbol = 'S', productions = productions }
+      assert.is_nil(parser.parse('bc!rest', grammar))
+    end)
+  end)
+end)
+
+describe('parser for', function()
+  describe('snippet header', function()
+    it('should match tab_trigger including quotes when no r option or multiword trigger', function()
+      local result = parser.parse_snippet_header('"snip"')
+      local expected = {
+        tab_trigger = '"snip"'
+      }
+      assert.are_same(expected, result)
+    end)
+
+    it('should match multiword tab-trigger surrounded with "!"', function()
+      local result = parser.parse_snippet_header('!"some" trigger! "a description"')
+      local expected = {
+        description = 'a description',
+        tab_trigger = '"some" trigger'
+      }
+      assert.are_same(expected, result)
+    end)
+
+    it('should match quoted tab_trigger, description, options', function()
+      local result = parser.parse_snippet_header('"tab - trigger"  "some description"   options')
+      local expected = {
+        options = 'options',
+        description = 'some description',
+        tab_trigger = 'tab - trigger'
+      }
+      assert.are_same(expected, result)
+    end)
+
+    it('should remove surrounding from tab_trigger when regex option is provided', function()
+      local result = parser.parse_snippet_header('|^(foo|bar)$| "" r')
+      local expected = {
+        options = 'r',
+        description = '',
+        tab_trigger = '^(foo|bar)$'
+      }
+      assert.are_same(expected, result)
+    end)
+
+    it('should not remove surrounding from tab_trigger when regex option is not provided', function()
+      local result = parser.parse_snippet_header('|^(foo|bar)$| "" ba')
+      local expected = {
+        options = 'ba',
+        description = '',
+        -- keep surrounding '|'
+        tab_trigger = '|^(foo|bar)$|'
+      }
+      assert.are_same(expected, result)
+    end)
+
+    it('should match options with "!"', function()
+      local result = parser.parse_snippet_header('test "description" b!')
+      local expected = {
+        options = 'b!',
+        description = 'description',
+        tab_trigger = 'test'
+      }
+      assert.are_same(expected, result)
+    end)
+
+    it('should match options with expression', function()
+      local result = parser.parse_snippet_header('trigger "d" "expr" be')
+      local expected = {
+        options = 'be',
+        expression = 'expr',
+        description = 'd',
+        tab_trigger = 'trigger'
+      }
+      assert.are_same(expected, result)
+      -- failure case
+      assert.are_same({}, parser.parse_snippet_header('trigger "d" "expr" br'))
+    end)
+
+    it('should not match invalid multiword tab-trigger', function()
+      local result = parser.parse_snippet_header('invalid multiword-trigger "description"')
+      assert.are_same({}, result)
+    end)
+  end)
+end)


### PR DESCRIPTION
Implementation of a parser for UltiSnips snippet headers in Lua.

This was mainly added because of the following reasons:
- UltiSnips does currently not provide *any* snippet information
  about regex snippets to third parties.
- For non-regex snippets (option r), `UltiSnips#SnippetsInCurrentScope()`
  provides basic information about the snippet locations as well as the
  description. However, the tab_trigger, options, or expression values
  are not provided.
For a possible use case of this parser and further context, see https://github.com/quangnguyen30192/cmp-nvim-ultisnips/pull/19.
---
So I have finally managed to finish the parser :) I tried to pay special attention to edge cases (like the `e` option in a snippet header) and confirmed the behavior using UltiSnips [own implementation](https://github.com/SirVer/ultisnips/blob/53e1921e3ef015ef658e540c0aa9c4835f9c18a6/pythonx/UltiSnips/snippet/source/file/ulti_snips.py#L82) and test cases. It is now possible to do the following:

For this snippet:
```
snippet "tab trigger" "description" b
```

```lua
local snippet_info = require('cmp_nvim_ultisnips.parser').parse_snippet_header(input) 
-- (input must not contain the prefix `snippet `)
```
calling the parser will return a table
```lua
snippet_info = {
  tab_trigger = "tab trigger",
  description = "description",
  options = "b"  
}
```
which we can now use in future PRs to let users customize what cmp will display :tada: 

I also added some tests which can be run with busted from the repo's root directory: 
`busted --directory lua cmp_nvim_ultisnips/tests`

Note that we cannot currently use `vim.` functions in the tests, however https://github.com/nvim-lua/plenary.nvim provides this functionality. I think this should be done in the next PR including automated testing.

Please review and suggest improvements!
