### PR TITLE
feat, refactor: make use of new parser for nicer cmp preview docs

### DIFF
--- a/lua/cmp_nvim_ultisnips/parser.lua
+++ b/lua/cmp_nvim_ultisnips/parser.lua
@@ -115,7 +115,7 @@ function M.parse_snippet_header(input)
       end
     },
     tab_trigger = {
-      rhs = { '^[^"%A]+', '^".-"', '^%S.+%S' },
+      rhs = { '^[^"%A]+', '^%S.+%S' },
     },
     description = {
       rhs = { '^"([^"]*)"' }

--- a/lua/cmp_nvim_ultisnips/snippets.lua
+++ b/lua/cmp_nvim_ultisnips/snippets.lua
@@ -1,40 +1,86 @@
-local M = {}
+local util = require('vim.lsp.util')
+local parser = require('cmp_nvim_ultisnips.parser')
 
-local ft_snippets_cache = {}
+local snippet_info_for_file = {}
 
-function M.load()
-  if ft_snippets_cache[vim.bo.filetype] == nil then
-    vim.F.npcall(vim.call, 'UltiSnips#SnippetsInCurrentScope', 1)
-    ft_snippets_cache[vim.bo.filetype] = vim.g.current_ulti_dict_info
+local function parse_snippets(snippets_file_path)
+  local cur_info = snippet_info_for_file[snippets_file_path]
+  if cur_info ~= nil then
+    return cur_info
   end
+  snippet_info_for_file[snippets_file_path] = {}
+  cur_info = {}
+  local content = vim.fn.readfile(snippets_file_path)
+  local found_snippet_header = false
 
-  return ft_snippets_cache[vim.bo.filetype]
-end
-
-function M.get_snippet_preview(user_data)
-  local filepath = string.gsub(user_data.location, '.snippets:%d*', '.snippets')
-  local _, _, linenr = string.find(user_data.location, ':(%d+)')
-  local content = vim.fn.readfile(filepath)
-
-  local snippet = {}
-  local count = 0
-
-  table.insert(snippet, '```' .. vim.bo.filetype)
-  for i, line in pairs(content) do
-    if i > linenr - 1 then
-      local is_snippet_header = line:find('^snippet%s[^%s]') ~= nil
-      count = count + 1
-      if line:find('^endsnippet') ~= nil or is_snippet_header and count ~= 1 then
-        break
+  for _, line in ipairs(content) do
+    local stripped_header = line:match('^%s*snippet%s+(.*)')
+    -- found possible snippet header
+    if stripped_header ~= nil then
+      local header_info = parser.parse_snippet_header(stripped_header)
+      if not vim.tbl_isempty(header_info) then
+        cur_info = header_info
+        cur_info.content = {}
+        found_snippet_header = true
       end
-      if not is_snippet_header then
-        table.insert(snippet, line)
-      end
+    elseif found_snippet_header and line:match('^endsnippet') ~= nil then
+      table.insert(snippet_info_for_file[snippets_file_path], cur_info)
+      found_snippet_header = false
+    elseif found_snippet_header then
+      table.insert(cur_info.content, line)
     end
   end
-  table.insert(snippet, '```')
+  return snippet_info_for_file[snippets_file_path]
+end
 
-  return snippet
+-- stores all parsed snippet information for a particular file type
+local snippet_info_for_ft = {}
+
+local M = {}
+
+function M.load_snippet_info()
+  local ft = vim.bo.filetype
+  local snippet_info = snippet_info_for_ft[ft]
+  if snippet_info == nil then
+    snippet_info = {}
+    vim.F.npcall(vim.call, 'UltiSnips#SnippetsInCurrentScope', 1)
+
+    local filepaths_set = {}
+    for _, info in pairs(vim.g.current_ulti_dict_info) do
+      local filepath = string.gsub(info.location, '.snippets:%d*', '.snippets')
+      filepaths_set[filepath] = true
+    end
+
+    for filepath, _ in pairs(filepaths_set) do
+      local result = parse_snippets(filepath)
+      snippet_info = vim.tbl_deep_extend('force', snippet_info, result)
+    end
+  end
+  return snippet_info
+end
+
+local function format_snippet_content(content)
+  local snippet_content = {}
+
+  table.insert(snippet_content, '```' .. vim.bo.filetype)
+  for _, line in ipairs(content) do
+    table.insert(snippet_content, line)
+  end
+  table.insert(snippet_content, '```')
+
+  local snippet_docs = util.convert_input_to_markdown_lines(snippet_content)
+  return table.concat(snippet_docs, '\n')
+end
+
+-- returns the documentation string that will be shown by cmp
+function M.documentation(snippet_info)
+  local description = ''
+  if snippet_info.description then
+    -- italicize description
+    description = '*' .. snippet_info.description ..  '*'
+  end
+  local header = description .. '\n\n'
+  return header .. format_snippet_content(snippet_info.content)
 end
 
 return M


### PR DESCRIPTION
Now the parser introduced in #20 is utilized to provide more info to
cmp items. This info is used to improve the cmp documentation / preview
window (currently defaults to a hardcoded implementation showing
the description and snippet contents).

Snippets with option 'r' or 'e' are parsed but not passed on to cmp
at the moment.

Here is a screenshot for a snippet with the following definition:
```
snippet tabt "Some description"
The snippet contents
endsnippet
```
![cnu-documentation_preview](https://user-images.githubusercontent.com/40792180/143299590-c009627b-2a8b-46d9-a5f1-8f3ded001c85.png)

The documentation is provided by a function that takes the snippet info table as a parameter
and returns a string. We could let users overwrite this so they can display whatever they
want, e.g. also show the options associated with a snippet.

I have tested this and it should work (also the tests still pass). But please test this PR first before merging :)
Suggestions for improvement / changes are welcome.
