### PR TITLE
Fix (parser): handle more snippet header edge cases

### DIFF
--- a/lua/cmp_nvim_ultisnips/parser.lua
+++ b/lua/cmp_nvim_ultisnips/parser.lua
@@ -35,7 +35,7 @@ function M.handle_non_terminal_symbol(production_name, grammar, input, force_par
       symbols = { rule }
     end
 
-    for symbol_num, symbol in ipairs(symbols) do
+    for _, symbol in ipairs(symbols) do
       local is_terminal_symbol = (grammar.productions[symbol] == nil)
 
       local result
@@ -115,7 +115,7 @@ function M.parse_snippet_header(input)
       end
     },
     tab_trigger = {
-      rhs = { '^[^"%A]+', '^%S.+%S' },
+      rhs = { '^.+%S*' },
     },
     description = {
       rhs = { '^"([^"]*)"' }

--- a/lua/cmp_nvim_ultisnips/snippets.lua
+++ b/lua/cmp_nvim_ultisnips/snippets.lua
@@ -14,14 +14,16 @@ local function parse_snippets(snippets_file_path)
   local found_snippet_header = false
 
   for _, line in ipairs(content) do
-    local stripped_header = line:match('^%s*snippet%s+(.-)%s*$')
-    -- found possible snippet header
-    if stripped_header ~= nil then
-      local header_info = parser.parse_snippet_header(stripped_header)
-      if not vim.tbl_isempty(header_info) then
-        cur_info = header_info
-        cur_info.content = {}
-        found_snippet_header = true
+    if not found_snippet_header then
+      local stripped_header = line:match('^%s*snippet%s+(.-)%s*$')
+      -- found possible snippet header
+      if stripped_header ~= nil then
+        local header_info = parser.parse_snippet_header(stripped_header)
+        if not vim.tbl_isempty(header_info) then
+          cur_info = header_info
+          cur_info.content = {}
+          found_snippet_header = true
+        end
       end
     elseif found_snippet_header and line:match('^endsnippet') ~= nil then
       table.insert(snippet_info_for_file[snippets_file_path], cur_info)

--- a/lua/cmp_nvim_ultisnips/tests/parser_spec.lua
+++ b/lua/cmp_nvim_ultisnips/tests/parser_spec.lua
@@ -264,5 +264,24 @@ describe('parser for', function()
       local result = parser.parse_snippet_header('func "Function Header" ')
       assert.are_same({}, result)
     end)
+
+    it('should match tab-trigger containing dot', function()
+      local result = parser.parse_snippet_header('j.u')
+      local expected = {
+        tab_trigger = 'j.u'
+      }
+      assert.are_same(expected, result)
+    end)
+
+    it('should match tab_trigger with less than 3 chars', function()
+      local result = parser.parse_snippet_header('c "Constructor" b')
+      local expected = {
+        tab_trigger = 'c',
+        description = 'Constructor',
+        options = 'b'
+      }
+      assert.are_same(expected, result)
+    end)
+
   end)
 end)


### PR DESCRIPTION
Also improves performance by only parsing headers that are expected, i.e. that are preceded by an end_snippet.