### PR TITLE
Refactor / fixes: retrieve snippet information directly from UltiSnips

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,31 +119,32 @@ Note: calling the setup function is only required if you wish to customize this 
 ### Example Configuration
 ```lua
 require("cmp-nvim-ultisnips").setup {
-  documentation = function(snippet_info)
-    return snippet_info.description
+  documentation = function(snippet)
+    return snippet.description
   end
 }
 ```
 
 ### Available Options
-In this section, `snippet_info` is a table that contains the following information about a snippet:
+In this section, `snippet` is a table that contains the following information about a snippet:
 ```lua
-snippet_info = {
-  tab_trigger = ... -- type: string, never nil
-  description = ... -- type: string, optional
-  options = ... -- type: string, optional
-  expression = ... -- type: string, only present for snippets with the 'e' option
+snippet = {
+  trigger = ... -- type: string
+  description = ... -- type: string
+  options = ... -- type: string
 
-  -- type: table of strings, where each string is one line in the snippet definition, never nil
-  content = { ... }
+  -- type: table of strings, where each string is one line in the snippet definition
+  value = { ... }
 }
 ```
+If some value was not specified in the snippet definition, the table will contain an empty string for that key.
+
 ---
 
-`documentation(snippet_info: {})`
+`documentation(snippet: {})`
 
 **Returns**: a string that is shown by cmp in the documentation window.
-If `nil` is returned, the documentation window will not appear for this snippet.
+If an empty string (`""`) is returned, the documentation window will not appear for that snippet.
 
 **Default value:** `require('cmp_nvim_ultisnips.snippets').documentation`
 

--- a/after/plugin/cmp_nvim_ultisnips.lua
+++ b/after/plugin/cmp_nvim_ultisnips.lua
@@ -1,4 +1,5 @@
 require('cmp').register_source('ultisnips', require('cmp_nvim_ultisnips').create_source())
+
 vim.cmd[[
 command! -nargs=0 CmpUltisnipsReloadSnippets lua require('cmp_nvim_ultisnips').reload_snippets()
 ]]

--- a/autoload/cmp_nvim_ultisnips.vim
+++ b/autoload/cmp_nvim_ultisnips.vim
@@ -1,0 +1,40 @@
+" Retrieves additional snippet information that is not directly accessible
+" using the UltiSnips API functions. Returns a list of tables (one table
+" per snippet) with the keys "trigger", "description" and "options".
+"
+" If 'expandable_only' is 1, only expandable snippets are returned, otherwise all
+" snippets for the current filetype are returned.
+function! cmp_nvim_ultisnips#get_current_snippets(expandable_only)
+pythonx << EOF
+import vim
+from UltiSnips import vim_helper
+
+expandable_only = vim.eval("a:expandable_only")
+if expandable_only == 1:
+    before = vim_helper.buf.line_till_cursor
+    snippets = UltiSnips_Manager._snips(before, True)
+else:
+    snippets = UltiSnips_Manager._snips("", True)
+
+snippets_info = []
+vim.command('let g:_cmpu_current_snippets = []')
+for snippet in snippets:
+    # Use Lua because it was the only way to achieve correct string escaping.
+    # Without this, '" in a trigger string did cause problems when converting
+    # to a vim dict. If you have a better way to do this, please file a PR.
+    # TODO: replace with vim.s (requires Nvim 0.6)
+    vim.command("lua vim.b._cmpu_snippet_trigger = [[%s]]" % str(snippet._trigger))
+    vim.command("lua vim.b._cmpu_snippet_description = [[%s]]" % str(snippet._description))
+    vim.command("lua vim.b._cmpu_snippet_options = [[%s]]" % str(snippet._opts))
+    vim.command("lua vim.b._cmpu_snippet_value = [[%s]]" % str(snippet._value))
+    vim.command(
+      "call add(g:_cmpu_current_snippets, {"\
+        "'trigger': b:_cmpu_snippet_trigger,"\
+        "'description': b:_cmpu_snippet_description,"\
+        "'options': b:_cmpu_snippet_options,"\
+        "'value': b:_cmpu_snippet_value,"\
+      "})"
+    )
+EOF
+return g:_cmpu_current_snippets
+endfunction

--- a/lua/cmp_nvim_ultisnips/init.lua
+++ b/lua/cmp_nvim_ultisnips/init.lua
@@ -22,4 +22,6 @@ function M.reload_snippets()
   source.clear_snippet_caches()
 end
 
+
+
 return M

--- a/lua/cmp_nvim_ultisnips/snippets.lua
+++ b/lua/cmp_nvim_ultisnips/snippets.lua
@@ -1,93 +1,45 @@
 local util = require('vim.lsp.util')
-local parser = require('cmp_nvim_ultisnips.parser')
-
-local snippet_info_for_file = {}
-
-local function parse_snippets(snippets_file_path)
-  local cur_info = snippet_info_for_file[snippets_file_path]
-  if cur_info ~= nil then
-    return cur_info
-  end
-  snippet_info_for_file[snippets_file_path] = {}
-  cur_info = {}
-  local content = vim.fn.readfile(snippets_file_path)
-  local found_snippet_header = false
-
-  for _, line in ipairs(content) do
-    if not found_snippet_header then
-      local stripped_header = line:match('^%s*snippet%s+(.-)%s*$')
-      -- found possible snippet header
-      if stripped_header ~= nil then
-        local header_info = parser.parse_snippet_header(stripped_header)
-        if not vim.tbl_isempty(header_info) then
-          cur_info = header_info
-          cur_info.content = {}
-          found_snippet_header = true
-        end
-      end
-    elseif found_snippet_header and line:match('^endsnippet') ~= nil then
-      table.insert(snippet_info_for_file[snippets_file_path], cur_info)
-      found_snippet_header = false
-    elseif found_snippet_header then
-      table.insert(cur_info.content, line)
-    end
-  end
-  return snippet_info_for_file[snippets_file_path]
-end
-
--- stores all parsed snippet information for a particular file type
-local snippet_info_for_ft = {}
 
 local M = {}
 
-function M.load_snippet_info()
+-- Caches all retrieved snippets information per filetype
+local snippets_info_for_ft = {}
+
+function M.load_snippets(expandable_only)
   local ft = vim.bo.filetype
-  local snippet_info = snippet_info_for_ft[ft]
-  if snippet_info == nil then
-    snippet_info = {}
-    vim.F.npcall(vim.call, 'UltiSnips#SnippetsInCurrentScope', 1)
-
-    local filepaths_set = {}
-    for _, info in pairs(vim.g.current_ulti_dict_info) do
-      local filepath = string.gsub(info.location, '.snippets:%d*', '.snippets')
-      filepaths_set[filepath] = true
-    end
-
-    for filepath, _ in pairs(filepaths_set) do
-      local result = parse_snippets(filepath)
-      snippet_info = vim.tbl_deep_extend('force', snippet_info, result)
-    end
+  local snippets_info = snippets_info_for_ft[ft]
+  if not snippets_info then
+    local expandable = expandable_only and 1 or 0
+    snippets_info = vim.fn["cmp_nvim_ultisnips#get_current_snippets"](expandable)
+    snippets_info_for_ft[ft] = snippets_info
   end
-  return snippet_info
+  return snippets_info
 end
 
 function M.clear_caches()
-  snippet_info_for_file = {}
-  snippet_info_for_ft = {}
+  snippets_info_for_ft = {}
 end
 
-function M.format_snippet_content(content)
-  local snippet_content = {}
-
-  table.insert(snippet_content, '```' .. vim.bo.filetype)
-  for _, line in ipairs(content) do
-    table.insert(snippet_content, line)
-  end
-  table.insert(snippet_content, '```')
-
-  local snippet_docs = util.convert_input_to_markdown_lines(snippet_content)
-  return table.concat(snippet_docs, '\n')
+function M.format_snippet_value(value)
+  local ft = vim.bo.filetype
+  -- turn \\n into \n to get "real" whitespace
+  local unescaped_value = value:gsub('\\([ntrab])', {
+    n = '\n', t = '\t',  r = '\r',  a = '\a',  b = '\b'
+  })
+  local snippet_docs = string.format('```%s\n%s\n```', ft, unescaped_value)
+  local lines = util.convert_input_to_markdown_lines(snippet_docs)
+  return table.concat(lines, '\n')
 end
 
--- returns the documentation string that will be shown by cmp
-function M.documentation(snippet_info)
+-- Returns the documentation string shown by cmp
+function M.documentation(snippet)
   local description = ''
-  if snippet_info.description then
-    -- italicize description
-    description = '*' .. snippet_info.description ..  '*'
+  if snippet.description ~= '' then
+    -- Italicize description
+    description = '*' .. snippet.description ..  '*'
   end
-  local header = description .. '\n\n'
-  return header .. M.format_snippet_content(snippet_info.content)
+  local formatted_value = M.format_snippet_value(snippet.value)
+  return string.format('%s\n\n%s', description, formatted_value)
 end
 
 return M

--- a/lua/cmp_nvim_ultisnips/source.lua
+++ b/lua/cmp_nvim_ultisnips/source.lua
@@ -18,15 +18,16 @@ end
 
 function source:complete(_, callback)
   local items = {}
-  local info = cmp_snippets.load_snippet_info()
-  for _, snippet_info in pairs(info) do
-    -- skip regex and expression snippets for now
-    if not snippet_info.options or not snippet_info.options:match('[re]') then
+  -- Retrieve all snippets for now (including not expandable ones)
+  local snippets = cmp_snippets.load_snippets(false)
+  for _, snippet in pairs(snippets) do
+    -- Skip regex and expression snippets for now
+    if not snippet.options:match('[re]') then
       local item = {
-        word =  snippet_info.tab_trigger,
-        label = snippet_info.tab_trigger,
+        word =  snippet.trigger,
+        label = snippet.trigger,
         kind = cmp.lsp.CompletionItemKind.Snippet,
-        userdata = snippet_info,
+        snippet = snippet
       }
       table.insert(items, item)
     end
@@ -35,7 +36,7 @@ function source:complete(_, callback)
 end
 
 function source.resolve(self, completion_item, callback)
-  local doc_string = self.config.documentation(completion_item.userdata)
+  local doc_string = self.config.documentation(completion_item.snippet)
   if doc_string ~= nil then
     completion_item.documentation = {
       kind = cmp.lsp.MarkupKind.Markdown,


### PR DESCRIPTION
This is basically the start of a complete overhaul of how this plugin
works.

In the last weeks, I have tried to make the way snippets are displayed
and handled (e.g. regex snippets) more customizable.
Since UltiSnips does not have a public API to retrieve all useful
information about snippets, I created a custom parser for snippet
headers (basically reinventing the wheel...).

Now we just interface with UltiSnips directly via Python and get all
the information about snippets for free.

No more custom parsing, edge cases, etc. - everything just works.

Thanks to @ColinKennedy for the inspiration (#18).

Closes #25.

---

I also updated the readme, it now uses `snippet` instead of `snippet_info` since they're basically the same now ;)

Next, I will remove the now unnecessary parser files + tests (kind of sad but awesome at the same time :sweat_smile:) and address #18.