### PR TITLE
Feat: only show snippets that are currently expandable (opt-out)

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,7 @@ Note: calling the setup function is only required if you wish to customize this 
 ### Example Configuration
 ```lua
 require("cmp-nvim-ultisnips").setup {
+  show_snippets = "all",
   documentation = function(snippet)
     return snippet.description
   end
@@ -141,9 +142,18 @@ If some value was not specified in the snippet definition, the table will contai
 
 ---
 
+`show_snippets: "expandable" | "all"`
+
+If set to `"expandable"`, only those snippets currently expandable by UltiSnips will be
+shown by cmp. `"all"` will show all snippets for the current filetype.
+
+**Default value:** `"expandable"`
+
+---
+
 `documentation(snippet: {})`
 
-**Returns**: a string that is shown by cmp in the documentation window.
+**Returns:** a string that is shown by cmp in the documentation window.
 If an empty string (`""`) is returned, the documentation window will not appear for that snippet.
 
 **Default value:** `require("cmp_nvim_ultisnips.snippets").documentation`
@@ -164,8 +174,6 @@ The temporary solution is to set the runtimepath as follows:
 ```lua
 use {"honza/vim-snippets", rtp = "."}
 ```
-
----
 
 UltiSnips was auto-removing tab mappings for select mode, that way it was not possible to jump through snippet stops.
 We have to disable this by setting `UltiSnipsRemoveSelectModeMappings = 0` (Credit [JoseConseco](https://github.com/quangnguyen30192/cmp-nvim-ultisnips/issues/5))

--- a/autoload/cmp_nvim_ultisnips.vim
+++ b/autoload/cmp_nvim_ultisnips.vim
@@ -10,7 +10,7 @@ import vim
 from UltiSnips import vim_helper
 
 expandable_only = vim.eval("a:expandable_only")
-if expandable_only == 1:
+if expandable_only == "True":
     before = vim_helper.buf.line_till_cursor
     snippets = UltiSnips_Manager._snips(before, True)
 else:

--- a/lua/cmp_nvim_ultisnips/init.lua
+++ b/lua/cmp_nvim_ultisnips/init.lua
@@ -4,12 +4,23 @@ local cmpu_snippets = require("cmp_nvim_ultisnips.snippets")
 local M = {}
 
 local default_config = {
+  show_snippets = "expandable",
   documentation = cmpu_snippets.documentation,
 }
 
 local user_config = default_config
 function M.setup(config)
   user_config = vim.tbl_deep_extend("force", default_config, config)
+  vim.validate({
+    show_snippets = {
+      user_config.show_snippets,
+      function(arg)
+        return arg == "expandable" or arg == "all"
+      end,
+      "either 'expandable' or 'all'",
+    },
+    documentation = { user_config.documentation, "function" },
+  })
 end
 
 local source

--- a/lua/cmp_nvim_ultisnips/snippets.lua
+++ b/lua/cmp_nvim_ultisnips/snippets.lua
@@ -6,11 +6,15 @@ local M = {}
 local snippets_info_for_ft = {}
 
 function M.load_snippets(expandable_only)
+  if expandable_only then
+    -- Do not cache snippets since the set of expandable
+    -- snippets can change on every keystroke.
+    return vim.fn["cmp_nvim_ultisnips#get_current_snippets"](true)
+  end
   local ft = vim.bo.filetype
   local snippets_info = snippets_info_for_ft[ft]
   if not snippets_info then
-    local expandable = expandable_only and 1 or 0
-    snippets_info = vim.fn["cmp_nvim_ultisnips#get_current_snippets"](expandable)
+    snippets_info = vim.fn["cmp_nvim_ultisnips#get_current_snippets"](false)
     snippets_info_for_ft[ft] = snippets_info
   end
   return snippets_info

--- a/lua/cmp_nvim_ultisnips/source.lua
+++ b/lua/cmp_nvim_ultisnips/source.lua
@@ -5,6 +5,7 @@ local source = {}
 function source.new(config)
   local self = setmetatable({}, { __index = source })
   self.config = config
+  self.expandable_only = config.show_snippets == "expandable"
   return self
 end
 
@@ -16,10 +17,9 @@ function source:get_debug_name()
   return "ultisnips"
 end
 
-function source:complete(_, callback)
+function source.complete(self, _, callback)
   local items = {}
-  -- Retrieve all snippets for now (including not expandable ones)
-  local snippets = cmp_snippets.load_snippets(false)
+  local snippets = cmp_snippets.load_snippets(self.expandable_only)
   for _, snippet in pairs(snippets) do
     -- Skip regex and expression snippets for now
     if not snippet.options:match("[re]") then


### PR DESCRIPTION
This is now enabled by default. When you have this snippet:
```
snippet abc "desc" b
value
endsnippet
```
and you type "a" at the beginning of a line, the snippet will be shown.
However, if you type it "a" the middle of a line it won't be shown (so this respects
snippet options now).

I also added a call to `vim.verify` that will check whether the parameter types of a
user's config parameters match the expected ones.

Waiting for your review, then will squash the commits into one.