### PR TITLE
Feat: add composable mappings, e.g. use a separate key to jump between snippet tabstops

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@
 
 ## Installation and Recommended Mappings
 
+Check out the [Mappings](#Mappings) section if you want to define your own mappings.
+
 ```lua
 use({
   "hrsh7th/nvim-cmp",
@@ -32,79 +34,92 @@ use({
         { name = "ultisnips" },
         -- more sources
       },
-      --[[
-      Configuration for <Tab> people:
-      <Tab> (and <S-Tab>)
-        cycle forward (backward) through completion items
-        and snippet tabstops / placeholders
-
-      <Tab>
-        to expand a snippet when no completion item is selected
-      ]]
+      -- recommended configuration for <Tab> people:
       mapping = {
-        ["<Tab>"] = cmp.mapping(function(fallback)
-          cmp_ultisnips_mappings.expand_or_jump_forwards(fallback)
-        end, {
-          "i",
-          "s",
-          -- add this line when using cmp-cmdline:
-          -- "c",
-        }),
-        ["<S-Tab>"] = cmp.mapping(function(fallback)
-          cmp_ultisnips_mappings.jump_backwards(fallback)
-        end, {
-          "i",
-          "s",
-          -- add this line when using cmp-cmdline:
-          -- "c",
-        }),
+        ["<Tab>"] = cmp.mapping(
+          function(fallback)
+            cmp_ultisnips_mappings.expand_or_jump_forwards(fallback)
+          end,
+          { "i", "s", [[ "c" (to enable the mapping in command mode) ]] }
+        ),
+        ["<S-Tab>"] = cmp.mapping(
+          function(fallback)
+            cmp_ultisnips_mappings.jump_backwards(fallback)
+          end,
+          { "i", "s", [[ "c" (to enable the mapping in command mode) ]] }
+        ),
       },
     })
   end,
 })
 ```
 
-## Reloading Snippets
-When the option `show_snippets` is set to `expandable` (see customization section; this is the default),
-the snippets are not cached and thus automatically reloaded after you modified your snippet definitions.
+## Mappings
 
-When set to `all`, you can manually reload the snippets with the command
-`:CmpUltisnipsReloadSnippets` and e.g. use it in an autocommand:
+You can compose your own mappings that are comprised of the following actions:
+- `expand`: expands the current snippet if the completion window is closed
+- `jump_forwards` / `jump_backwards`: jumps to the next / previous snippet tabstop
+- `select_next_item` / `select_prev_item`: selects the next / previous completion item
+
+The recommended mappings use the `compose` function under the hood:
+```lua
+function M.expand_or_jump_forwards(fallback)
+  M.compose({ "expand", "jump_forwards", "select_next_item" })(fallback)
+end
+
+function M.jump_backwards(fallback)
+  M.compose({ "jump_backwards", "select_prev_item" })(fallback)
+end
+```
+
+For example, if you prefer a separate key for jumping between snippet tabstops you can do
+the following:
+
+
+```lua
+local cmp_ultisnips_mappings = require("cmp_nvim_ultisnips.mappings")
+-- In your cmp setup:
+...
+mapping = {
+  ["<Tab>"] = cmp.mapping(
+    function(fallback)
+      cmp_ultisnips_mappings.compose({ "expand", "select_next_item" })(fallback)
+    end,
+    ...
+```
+
+These actions are implemented as a table `{ condition = ..., command = ... }`.
+If the condition for an action fails, the next action (in the order as the action keys are passed to `compose`) is tried until the first condition matches.
+Then the `command` function is run. If none match, `fallback` is called.
+
+## Customization
+
+### Available Options
+
+`show_snippets: "expandable" | "all"`
+
+If set to `"expandable"`, only those snippets currently expandable by UltiSnips will be
+shown. The snippets will always be in sync with the currently available UltiSnips snippets.
+
+`"all"` will show all snippets for the current filetype. If using this option, be aware
+that all snippets for the current buffer will be cached (even if the snippet definitions
+changed). You can then manually reload the snippets with the command `:CmpUltisnipsReloadSnippets`
+or by using an autocommand:
 
 ```vim
 autocmd BufWritePost *.snippets :CmpUltisnipsReloadSnippets
 ```
 
-## Customization
-Note: calling the setup function is only required if you wish to customize this plugin.
-### Example Configuration
-```lua
-require("cmp_nvim_ultisnips").setup {
-  show_snippets = "all",
-  documentation = function(snippet)
-    return snippet.description
-  end
-}
-```
-
-### Available Options
-In this section, `snippet` is a table that contains the following keys (each value is a string):
-
-- trigger, description, options, value
-
----
-
-`show_snippets: "expandable" | "all"`
-
-If set to `"expandable"`, only those snippets currently expandable by UltiSnips will be
-shown by cmp. `"all"` will show all snippets for the current filetype except regular
-expression snippets (option `r`) and custom context snippets (option `e`).
+Expression snippets (option `r`) and custom context snippets (option `e`) are never shown.
 
 **Default:** `"expandable"`
 
 ---
 
 `documentation(snippet: {}): function`
+
+`snippet` is a table that contains the following keys (each value is a string):
+- trigger, description, options, value
 
 **Returns:** a string that is shown by cmp in the documentation window.
 If an empty string (`""`) is returned, the documentation window will not appear for that snippet.
@@ -114,11 +129,24 @@ If an empty string (`""`) is returned, the documentation window will not appear 
 By default, this shows the snippet description at the top of the documentation window
 followed by the snippet content (see screenshot at the top of the readme).
 
+### Example Configuration
+
+Note: calling the setup function is only required if you wish to customize this plugin.
+
+```lua
+require("cmp_nvim_ultisnips").setup {
+  show_snippets = "all",
+  documentation = function(snippet)
+    return snippet.description
+  end
+}
+```
 
 ## Credit
 [Compe source for UltiSnips](https://github.com/hrsh7th/nvim-compe/blob/master/lua/compe_ultisnips/init.lua)
 
 ## Known Issues
+
 UltiSnips was auto-removing tab mappings for select mode, that way it was not possible to jump through snippet stops.
 We have to disable this by setting `UltiSnipsRemoveSelectModeMappings = 0` (Credit [JoseConseco](https://github.com/quangnguyen30192/cmp-nvim-ultisnips/issues/5))
 ```lua
@@ -130,4 +158,3 @@ use({
   end,
 })
 ```
-

--- a/lua/cmp_nvim_ultisnips/mappings.lua
+++ b/lua/cmp_nvim_ultisnips/mappings.lua
@@ -1,33 +1,69 @@
 local cmp = require("cmp")
 
-local M = {}
-
-local t = function(keys)
+local function t(keys)
   vim.api.nvim_feedkeys(vim.api.nvim_replace_termcodes(keys, true, true, true), "m", true)
+end
+
+local function can_execute(arg)
+  return cmp.get_selected_entry() == nil and vim.fn[arg]() == 1
 end
 
 -- The <Plug> mappings are defined in autoload/cmp_nvim_ultisnips.vim.
 
-function M.expand_or_jump_forwards(fallback)
-  if cmp.get_selected_entry() == nil and vim.fn["UltiSnips#CanExpandSnippet"]() == 1 then
-    t("<Plug>(cmpu-expand)")
-  elseif vim.fn["UltiSnips#CanJumpForwards"]() == 1 then
-    t("<Plug>(cmpu-jump-forwards)")
-  elseif cmp.visible() then
-    cmp.select_next_item()
-  else
+local actions = {
+  expand = {
+    condition = { can_execute, "UltiSnips#CanExpandSnippet" },
+    command = { t, "<Plug>(cmpu-expand)" },
+  },
+  jump_forwards = {
+    condition = { can_execute, "UltiSnips#CanJumpForwards" },
+    command = { t, "<Plug>(cmpu-jump-forwards)" },
+  },
+  jump_backwards = {
+    condition = { can_execute, "UltiSnips#CanJumpBackwards" },
+    command = { t, "<Plug>(cmpu-jump-backwards)" },
+  },
+  select_next_item = {
+    condition = { cmp.visible },
+    command = { cmp.select_next_item },
+  },
+  select_prev_item = {
+    condition = { cmp.visible },
+    command = { cmp.select_prev_item },
+  },
+}
+
+local M = {}
+
+function M.compose(action_keys)
+  return function(fallback)
+    for _, action_key in ipairs(action_keys) do
+      local action = actions[action_key]
+      if not action then
+        error(
+          string.format(
+            "[cmp_nvim_ultisnips.mappings] Invalid key %s was passed to compose function. "
+              .. "Please check your mappings.\nAllowed values: 'expand', 'jump_forwards', "
+              .. "'jump_backwards', 'select_next_item', 'select_prev_item'.",
+            action_key
+          )
+        )
+      end
+      if action.condition[1](action.condition[2]) == true then
+        action.command[1](action.command[2])
+        return
+      end
+    end
     fallback()
   end
 end
 
+function M.expand_or_jump_forwards(fallback)
+  M.compose({ "expand", "jump_forwards", "select_next_item" })(fallback)
+end
+
 function M.jump_backwards(fallback)
-  if vim.fn["UltiSnips#CanJumpBackwards"]() == 1 then
-    t("<Plug>(cmpu-jump-backwards)")
-  elseif cmp.visible() then
-    cmp.select_prev_item()
-  else
-    fallback()
-  end
+  M.compose({ "jump_backwards", "select_prev_item" })(fallback)
 end
 
 return M


### PR DESCRIPTION
- add "actions" users can use to compose their own mappings
- update readme