### PR TITLE
Fix(mappings): add missing select mode mappings

### DIFF
--- a/autoload/cmp_nvim_ultisnips.vim
+++ b/autoload/cmp_nvim_ultisnips.vim
@@ -65,11 +65,23 @@ function! cmp_nvim_ultisnips#setup_treesitter_autocmds()
 endfunction
 
 " Define silent mappings
+
+" More info on why CursorMoved is called can be found here:
+" https://github.com/SirVer/ultisnips/issues/1295#issuecomment-774056584
 imap <silent> <Plug>(cmpu-expand)
 \ <C-r>=[UltiSnips#CursorMoved(), UltiSnips#ExpandSnippet()][1]<cr>
 
+smap <silent> <Plug>(cmpu-expand)
+\ <Esc>:call UltiSnips#ExpandSnippetOrJump()<cr>
+
 imap <silent> <Plug>(cmpu-jump-forwards)
-\ <C-r>=[UltiSnips#CursorMoved(), UltiSnips#JumpForwards()][1]<cr>
+\ <C-r>=UltiSnips#JumpForwards()<cr>
+
+smap <silent> <Plug>(cmpu-jump-forwards)
+\ <Esc>:call UltiSnips#JumpForwards()<cr>
 
 imap <silent> <Plug>(cmpu-jump-backwards)
-\ <C-r>=[UltiSnips#CursorMoved(), UltiSnips#JumpBackwards()][1]<cr>
+\ <C-r>=UltiSnips#JumpBackwards()<cr>
+
+smap <silent> <Plug>(cmpu-jump-backwards)
+\ <C-r>=UltiSnips#JumpBackwards()<cr>


### PR DESCRIPTION
This makes nested mappings work the same as in UltiSnips. We should probably make the RemoveSelectModeMappings hint more visible in the readme.