### PR TITLE
Feat(mappings): set g:UltiSnipsRemoveSelectModeMappings = 0 so users don't have to

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -6,3 +6,11 @@ self = false
 read_globals = {
   "vim"
 }
+
+globals = {
+  vim = {
+    fields = {
+      g
+    }
+  }
+}

--- a/README.md
+++ b/README.md
@@ -165,17 +165,3 @@ require("cmp_nvim_ultisnips").setup {
 ## Credit
 - [Compe source for UltiSnips](https://github.com/hrsh7th/nvim-compe/blob/master/lua/compe_ultisnips/init.lua)
 - The Treesitter integration was inspired by [this Luasnip PR](https://github.com/L3MON4D3/LuaSnip/pull/226)
-
-## Known Issues
-
-UltiSnips was auto-removing tab mappings for select mode, that way it was not possible to jump through snippet stops.
-We have to disable this by setting `UltiSnipsRemoveSelectModeMappings = 0` (credit to [JoseConseco](https://github.com/quangnguyen30192/cmp-nvim-ultisnips/issues/5)).
-```lua
-use({
-  "SirVer/ultisnips",
-  requires = "honza/vim-snippets",
-  config = function()
-    vim.g.UltiSnipsRemoveSelectModeMappings = 0
-  end,
-})
-```

--- a/autoload/cmp_nvim_ultisnips.vim
+++ b/autoload/cmp_nvim_ultisnips.vim
@@ -84,4 +84,4 @@ imap <silent> <Plug>(cmpu-jump-backwards)
 \ <C-r>=UltiSnips#JumpBackwards()<cr>
 
 smap <silent> <Plug>(cmpu-jump-backwards)
-\ <C-r>=UltiSnips#JumpBackwards()<cr>
+\ <Esc>:call UltiSnips#JumpBackwards()<cr>

--- a/lua/cmp_nvim_ultisnips/init.lua
+++ b/lua/cmp_nvim_ultisnips/init.lua
@@ -10,8 +10,11 @@ end
 
 local source
 function M.create_source()
-  -- Source UltiSnips file in case it is not loaded yet (ref. #49)
+  -- Source UltiSnips file in case it is not loaded yet (GH issue #49)
   vim.cmd("runtime! plugin/UltiSnips.vim")
+  -- This is necessary because we want to be able to define our own
+  -- select mode mappings used to jump between snippet tabstops (GH issue #5)
+  vim.g.UltiSnipsRemoveSelectModeMappings = 0
   source = cmpu_source.new(user_config)
   return source
 end

--- a/lua/cmp_nvim_ultisnips/treesitter.lua
+++ b/lua/cmp_nvim_ultisnips/treesitter.lua
@@ -40,7 +40,7 @@ function M.set_filetype()
 end
 
 function M.reset_filetype()
-  if cur_ft_at_cursor ~= nil and cur_ft_at_cursor ~= vim.bo.filetype then
+  if cur_ft_at_cursor ~= nil then
     vim.fn["cmp_nvim_ultisnips#reset_filetype"]()
     cur_ft_at_cursor = nil
   end


### PR DESCRIPTION
This makes the "Known Issues" section in the readme superfluous.

Also fix the incorrect select mode mapping for jumping to the previous snippet tabstop.