### PR TITLE
Feat: add support for regular expression snippets

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@
 ## Features
 - **Composable Mappings**: get rid of boilerplate code in your config
 - **Treesitter Integration**: show snippets based on the filetype at your cursor position
+- **Regular Expression Snippets**: snippets with the 'r' option are supported
 - **Customization**: change which and how snippets are displayed by cmp
 
 ## Installation and Recommended Mappings

--- a/autoload/cmp_nvim_ultisnips.vim
+++ b/autoload/cmp_nvim_ultisnips.vim
@@ -13,11 +13,12 @@ from UltiSnips import UltiSnips_Manager, vim_helper
 
 if vim.eval("a:expandable_only") == "True":
     before = vim_helper.buf.line_till_cursor
+    vim.command("let g:_cmpu_line_till_cursor = py3eval('before')")
     snippets = UltiSnips_Manager._snips(before, True)
 else:
     snippets = UltiSnips_Manager._snips("", True)
 
-vim.command('let g:_cmpu_current_snippets = []')
+vim.command("let g:_cmpu_current_snippets = []")
 for snippet in snippets:
     vim.command(
       "call add(g:_cmpu_current_snippets, {"

--- a/lua/cmp_nvim_ultisnips/source.lua
+++ b/lua/cmp_nvim_ultisnips/source.lua
@@ -25,19 +25,29 @@ end
 function source.complete(self, _, callback)
   local items = {}
   local snippets = cmpu_snippets.load_snippets(self.expandable_only)
+
   for _, snippet in pairs(snippets) do
-    -- Skip regex and expression snippets for now
-    if not snippet.options:match("[re]") then
-      local item = {
-        word = snippet.trigger,
-        label = snippet.trigger,
-        kind = cmp.lsp.CompletionItemKind.Snippet,
-        snippet = snippet,
-      }
-      table.insert(items, item)
+    -- Skip expression snippets for now
+    if not snippet.options:match("e") then
+      local is_regex_snippet = snippet.options:match("r")
+      -- Avoid expanding a regex snippet with an invalid insertText when self.expandable_only == False
+      -- (_cmpu_line_till_cursor is only set when self.expandable_only == True)
+      if not is_regex_snippet or is_regex_snippet and self.expandable_only then
+        local item = {
+          insertText = vim.g._cmpu_line_till_cursor or snippet.trigger,
+          label = snippet.trigger,
+          kind = cmp.lsp.CompletionItemKind.Snippet,
+          snippet = snippet,
+        }
+        table.insert(items, item)
+      end
     end
   end
-  callback(items)
+  callback({
+    items = items,
+    -- Cmp will update the items on every keystroke
+    isIncomplete = self.expandable_only,
+  })
 end
 
 function source.resolve(self, completion_item, callback)


### PR DESCRIPTION
These are snippets with the 'r' option.
Only enabled when `show_snippets` is set to `"expandable"`.

---

We basically get this for free :) Don't know why I didn't think of this sooner :laughing:

Example for the following snippet:
```snippets
snippet "(R|r)e?ge?x!+" "A regex snippet" r
The snippet value
endsnippet
```
![cmpu_regex](https://user-images.githubusercontent.com/40792180/146785915-c90bd9f9-c911-41cb-a55f-ccea5eb72b94.png)