### PR TITLE
Fix(treesitter): improve performance by using TextChanged autocommands instead of CursorMovedI

### DIFF
--- a/autoload/cmp_nvim_ultisnips.vim
+++ b/autoload/cmp_nvim_ultisnips.vim
@@ -60,7 +60,7 @@ endfunction
 function! cmp_nvim_ultisnips#setup_treesitter_autocmds()
   augroup cmp_nvim_ultisnips
     autocmd!
-    autocmd CursorMovedI * lua require("cmp_nvim_ultisnips.treesitter").set_filetype()
+    autocmd TextChangedI,TextChangedP * lua require("cmp_nvim_ultisnips.treesitter").set_filetype()
     autocmd InsertLeave * lua require("cmp_nvim_ultisnips.treesitter").reset_filetype()
   augroup end
 endfunction


### PR DESCRIPTION
When the cursor moved the cmp window will not be shown anyway so we don't need to update the current treesitter filetype.