### PR TITLE
Feat: Add 'jump_forwards' mapping preset.

### DIFF
--- a/lua/cmp_nvim_ultisnips/mappings.lua
+++ b/lua/cmp_nvim_ultisnips/mappings.lua
@@ -62,6 +62,10 @@ function M.expand_or_jump_forwards(fallback)
   M.compose { "expand", "jump_forwards", "select_next_item" }(fallback)
 end
 
+function M.jump_forwards(fallback)
+  M.compose { "jump_forwards", "select_next_item" }(fallback)
+end
+
 function M.jump_backwards(fallback)
   M.compose { "jump_backwards", "select_prev_item" }(fallback)
 end


### PR DESCRIPTION
Hi!

I sometimes have multiple snippets that have a similar name, and I would like to cycle through them in the cmp suggestion popup using tab. The default/recommended `expand_or_jump_forwards` does not allow this:

![before](https://user-images.githubusercontent.com/5575698/211894936-5e8cf08b-ea2f-4026-b949-e4ecc234ef69.gif)

This adds a `jump_forwards` mapping "preset", which does not expand on tab:

![after](https://user-images.githubusercontent.com/5575698/211894973-d186f147-d568-4318-8d12-4d89e24cf1f6.gif)

Let me know if anything needs to be changed  or you don't feel this is needed - I am happy to keep having a 'compose' in my config.

Thanks for the great plugin!