### PR TITLE
Fix snippet doesnt work in comments or kdoc.

### DIFF
--- a/autoload/cmp_nvim_ultisnips.vim
+++ b/autoload/cmp_nvim_ultisnips.vim
@@ -71,7 +71,7 @@ endfunction
 function! cmp_nvim_ultisnips#setup_treesitter_autocmds()
   augroup cmp_nvim_ultisnips
     autocmd!
-    autocmd TextChangedI,TextChangedP * lua require("cmp_nvim_ultisnips.treesitter").set_filetype()
+    autocmd TextChangedP * lua require("cmp_nvim_ultisnips.treesitter").set_filetype()
     autocmd InsertLeave * lua require("cmp_nvim_ultisnips.treesitter").reset_filetype()
   augroup end
 endfunction


### PR DESCRIPTION

https://github.com/quangnguyen30192/cmp-nvim-ultisnips/assets/20348662/27102f9d-6d89-472c-9233-f97e56a9c503

As you can see on the screen recording, event TextChangedI make snippet stop working in comment block or KDoc (in kotlin). I'm not sure about the root cause but my concern is whether we can remove this event from autocmd set filetype or not? @quangnguyen30192 