### PR TITLE
perf: defer import ultisnips_utils

### DIFF
--- a/autoload/cmp_nvim_ultisnips.vim
+++ b/autoload/cmp_nvim_ultisnips.vim
@@ -29,3 +29,23 @@ function! cmp_nvim_ultisnips#initCustomUltiSnipMappings()
   smap <silent> <Plug>(cmpu-jump-backwards)
         \ <Esc>:call UltiSnips#JumpBackwards()<cr>
 endfunction
+
+" ------------------------------------------------------------------------
+" Wrappers for ultisnips_utils.py that defer the import to first use.
+" Saves 100+ ms of nvim startup time.
+" ------------------------------------------------------------------------
+
+function! cmp_nvim_ultisnips#fetch_current_snippets(expandable_only)
+  py3 import ultisnips_utils
+  return py3eval('ultisnips_utils.fetch_current_snippets(vim.eval("a:expandable_only"))')
+endfunction
+
+function! cmp_nvim_ultisnips#set_filetype(ft)
+  py3 import ultisnips_utils
+  py3 ultisnips_utils.set_filetype(vim.eval("a:ft"))
+endfunction
+
+function! cmp_nvim_ultisnips#reset_filetype()
+  py3 import ultisnips_utils
+  py3 ultisnips_utils.reset_filetype()
+endfunction

--- a/lua/cmp_nvim_ultisnips/init.lua
+++ b/lua/cmp_nvim_ultisnips/init.lua
@@ -12,7 +12,6 @@ local source
 function M.create_source()
   -- Source UltiSnips file in case it is not loaded yet (GH issue #49)
   vim.cmd("runtime! plugin/UltiSnips.vim")
-  vim.cmd("py3 import ultisnips_utils")
   -- This is necessary because we want to be able to define our own
   -- select mode mappings used to jump between snippet tabstops (GH issue #5)
   vim.g.UltiSnipsRemoveSelectModeMappings = 0

--- a/lua/cmp_nvim_ultisnips/snippets.lua
+++ b/lua/cmp_nvim_ultisnips/snippets.lua
@@ -9,12 +9,12 @@ function M.load_snippets(expandable_only)
   if expandable_only then
     -- Do not cache snippets since the set of expandable
     -- snippets can change on every keystroke.
-    return vim.fn.pyeval("ultisnips_utils.fetch_current_snippets(True)")
+    return vim.fn["cmp_nvim_ultisnips#fetch_current_snippets"](true)
   end
   local ft = vim.bo.filetype
   local snippets = snippets_for_ft[ft]
   if not snippets then
-    snippets = vim.fn.pyeval("ultisnips_utils.fetch_current_snippets(False)")
+    snippets = vim.fn["cmp_nvim_ultisnips#fetch_current_snippets"](false)
     snippets_for_ft[ft] = snippets
   end
   return snippets

--- a/lua/cmp_nvim_ultisnips/treesitter.lua
+++ b/lua/cmp_nvim_ultisnips/treesitter.lua
@@ -34,14 +34,14 @@ local cur_ft_at_cursor
 function M.set_filetype()
   local new_ft = get_ft_at_cursor()
   if new_ft ~= nil and new_ft ~= cur_ft_at_cursor and new_ft ~= vim.bo.filetype then
-    vim.fn.pyeval(('ultisnips_utils.set_filetype("%s")'):format(new_ft))
+    vim.fn["cmp_nvim_ultisnips#set_filetype"](new_ft)
     cur_ft_at_cursor = new_ft
   end
 end
 
 function M.reset_filetype()
   if cur_ft_at_cursor ~= nil then
-    vim.fn.pyeval("ultisnips_utils.reset_filetype()")
+    vim.fn["cmp_nvim_ultisnips#reset_filetype"]()
     cur_ft_at_cursor = nil
   end
 end

--- a/python3/ultisnips_utils.py
+++ b/python3/ultisnips_utils.py
@@ -1,3 +1,5 @@
+from UltiSnips import UltiSnips_Manager, vim_helper
+
 # Retrieves additional snippet information that is not directly accessible
 # using the UltiSnips API functions. Stores a list of dictionaries (one per
 # snippet) with the keys "trigger", "description", "options" and "value"
@@ -8,8 +10,6 @@
 
 
 def fetch_current_snippets(expandable_only):
-    from UltiSnips import UltiSnips_Manager, vim_helper
-
     line_until_cursor = vim_helper.buf.line_till_cursor
     visual_content = UltiSnips_Manager._visual_content
     if expandable_only:
@@ -42,8 +42,6 @@ def fetch_current_snippets(expandable_only):
 
 
 def set_filetype(ft):
-    from UltiSnips import vim_helper
-
     class CustomVimBuffer(vim_helper.VimBuffer):
         @property
         def filetypes(self):
@@ -54,6 +52,4 @@ def set_filetype(ft):
 
 
 def reset_filetype():
-    from UltiSnips import vim_helper
-
     vim_helper.buf = vim_helper._orig_buf


### PR DESCRIPTION

Importing ultisnips_utils in cmp_nvim_ultisnips.init.create_source causes nvim startup to take 150 ms more on my laptop. This is a regression introduced in <https://github.com/quangnguyen30192/cmp-nvim-ultisnips/pull/93>.
  
The fix is to defer the import until it's actually needed (the first time the completion source is used).
  
Fixes: https://github.com/quangnguyen30192/cmp-nvim-ultisnips/issues/100
Fixes: f5c5cd6da094 ("refactor: extract Python code to separate file")
  
---

also:

- **Revert (partially) "fix: defer import of UltiSnips modules"**
  Should not be needed now that ultisnips_utils.py itself is imported
  lazily.
  
  This reverts commit ae00afe981c9d58619b84a8c511826dd89705f4b.